### PR TITLE
Implement failOnWarnings config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Will do the same thing.
 | `buildLogFile` / `-f`     | yes, repeatable        |                              | Read below                                            |
 | `output` / `-o`           | no                     |                              | CodeCoach parsed output for debugging                 |
 | `removeOldComment` / `-r` | no                     | `true` or `false`            | Remove CodeCoach's old comments before adding new one |
+| `failOnWarnings`          | no                     | `true` or `false`            | Fail the job when warnings are found                  |
 
 
 ##### `--buildLogFile` or `-f`

--- a/src/Config/@types/configArgument.ts
+++ b/src/Config/@types/configArgument.ts
@@ -12,4 +12,5 @@ export type ConfigArgument = {
   buildLogFile: BuildLogFile[];
   output: string; // =logFilePath
   removeOldComment: boolean;
+  failOnWarnings: boolean;
 };

--- a/src/Config/Config.spec.ts
+++ b/src/Config/Config.spec.ts
@@ -39,6 +39,7 @@ const GITLAB_ENV_ARGS = [
   `--gitlabToken=${mockGitLabToken}`,
   `-f=${mockBuildLogFile}`,
   `-o=${mockOutput}`,
+  '--failOnWarnings',
 ];
 
 const GITLAB_FILE_ARGS = ['node', 'app.ts', '--config=sample/config/gitlab.json'];
@@ -63,6 +64,7 @@ describe('Config parsing Test', () => {
     expect(config.githubPr).toBe(mockGitHubPr);
     expect(config.githubToken).toBe(mockGitHubToken);
     expect(config.removeOldComment).toBe(true);
+    expect(config.failOnWarnings).toBe(false);
 
     validateBuildLog(config.buildLogFile);
   });
@@ -75,6 +77,7 @@ describe('Config parsing Test', () => {
     expect(config.githubPr).toBe(mockGitHubPr);
     expect(config.githubToken).toBe(mockGitHubToken);
     expect(config.removeOldComment).toBe(false);
+    expect(config.failOnWarnings).toBe(false);
 
     validateBuildLog(config.buildLogFile);
   });
@@ -88,6 +91,7 @@ describe('Config parsing Test', () => {
     expect(config.gitlabMrIid).toBe(mockGitLabMrIid);
     expect(config.gitlabToken).toBe(mockGitLabToken);
     expect(config.removeOldComment).toBe(false);
+    expect(config.failOnWarnings).toBe(true);
 
     validateBuildLog(config.buildLogFile);
   });
@@ -101,6 +105,7 @@ describe('Config parsing Test', () => {
     expect(config.gitlabMrIid).toBe(mockGitLabMrIid);
     expect(config.gitlabToken).toBe(mockGitLabToken);
     expect(config.removeOldComment).toBe(true);
+    expect(config.failOnWarnings).toBe(false);
 
     validateBuildLog(config.buildLogFile);
   });

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -99,6 +99,11 @@ and <cwd> is build root directory (optional (Will use current context as cwd)).
     describe: 'Remove existing CodeCoach comments before putting new one',
     default: false,
   })
+  .option('failOnWarnings', {
+    type: 'boolean',
+    describe: 'Fail the job if warnings are found',
+    default: false,
+  })
   .strict()
   .help()
   .wrap(120)

--- a/src/Provider/GitHub/GitHub.spec.ts
+++ b/src/Provider/GitHub/GitHub.spec.ts
@@ -121,7 +121,7 @@ describe('VCS: GitHub', () => {
 
   it('should set commit status as success when no error', async () => {
     const service = new PrServiceMock();
-    const github = new GitHub(service);
+    const github = new GitHub(service, false, false);
     await github.report([touchFileWarning]);
 
     expect(service.createReviewComment).toHaveBeenCalledTimes(1);
@@ -132,5 +132,67 @@ describe('VCS: GitHub', () => {
       CommitStatus.success,
       expect.any(String),
     );
+  });
+
+  it('should set commit status as failure when there is error', async () => {
+    const service = new PrServiceMock();
+    const github = new GitHub(service);
+    await github.report([touchFileError]);
+
+    expect(service.createReviewComment).toHaveBeenCalledTimes(1);
+    expect(service.createComment).toHaveBeenCalledTimes(1);
+    expect(service.setCommitStatus).toHaveBeenCalledTimes(1);
+    expect(service.setCommitStatus).toHaveBeenCalledWith(
+      mockedSha,
+      CommitStatus.failure,
+      expect.any(String),
+    );
+  });
+
+  describe('when failOnWarnings is true', () => {
+    it('should set commit status as success when no error or warning', async () => {
+      const service = new PrServiceMock();
+      const github = new GitHub(service, false, true);
+      await github.report([]);
+
+      expect(service.createReviewComment).toHaveBeenCalledTimes(0);
+      expect(service.createComment).toHaveBeenCalledTimes(0);
+      expect(service.setCommitStatus).toHaveBeenCalledTimes(1);
+      expect(service.setCommitStatus).toHaveBeenCalledWith(
+        mockedSha,
+        CommitStatus.success,
+        expect.any(String),
+      );
+    });
+
+    it('should set commit status as failure when there is error', async () => {
+      const service = new PrServiceMock();
+      const github = new GitHub(service, false, true);
+      await github.report([touchFileError]);
+
+      expect(service.createReviewComment).toHaveBeenCalledTimes(1);
+      expect(service.createComment).toHaveBeenCalledTimes(1);
+      expect(service.setCommitStatus).toHaveBeenCalledTimes(1);
+      expect(service.setCommitStatus).toHaveBeenCalledWith(
+        mockedSha,
+        CommitStatus.failure,
+        expect.any(String),
+      );
+    });
+
+    it('should set commit status as failure when there is warning', async () => {
+      const service = new PrServiceMock();
+      const github = new GitHub(service, false, true);
+      await github.report([touchFileWarning]);
+
+      expect(service.createReviewComment).toHaveBeenCalledTimes(1);
+      expect(service.createComment).toHaveBeenCalledTimes(1);
+      expect(service.setCommitStatus).toHaveBeenCalledTimes(1);
+      expect(service.setCommitStatus).toHaveBeenCalledWith(
+        mockedSha,
+        CommitStatus.failure,
+        expect.any(String),
+      );
+    });
   });
 });

--- a/src/Provider/GitHub/GitHub.ts
+++ b/src/Provider/GitHub/GitHub.ts
@@ -19,6 +19,7 @@ export class GitHub implements VCS {
   constructor(
     private readonly prService: IGitHubPRService,
     private readonly removeOldComment: boolean = false,
+    private readonly failOnWarnings: boolean = false,
   ) {}
 
   async report(logs: LogType[]): Promise<boolean> {
@@ -53,7 +54,10 @@ export class GitHub implements VCS {
   }
 
   private async setCommitStatus() {
-    const commitStatus = this.nError > 0 ? CommitStatus.failure : CommitStatus.success;
+    const passed = this.failOnWarnings
+      ? this.nError + this.nWarning === 0
+      : this.nError === 0;
+    const commitStatus = passed ? CommitStatus.success : CommitStatus.failure;
     const description = MessageUtil.generateCommitDescription(this.nError);
 
     await this.prService.setCommitStatus(this.commitId, commitStatus, description);

--- a/src/Provider/GitLab/GitLab.spec.ts
+++ b/src/Provider/GitLab/GitLab.spec.ts
@@ -39,13 +39,12 @@ describe('VCS: GitLab', () => {
     const gitLab = new GitLab(service, true);
 
     const result = await gitLab.report([
-      touchFileError,
       touchFileWarning,
       untouchedError,
       untouchedWarning,
     ]);
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   it('should returns false when there is some error', async () => {
@@ -53,12 +52,13 @@ describe('VCS: GitLab', () => {
     const gitLab = new GitLab(service, true);
 
     const result = await gitLab.report([
+      touchFileError,
       touchFileWarning,
       untouchedError,
       untouchedWarning,
     ]);
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it('should remove old self comments and reviews and post new ones', async () => {
@@ -105,5 +105,42 @@ describe('VCS: GitLab', () => {
 
     expect(service.createMRDiscussion).not.toHaveBeenCalled();
     expect(service.createNote).not.toHaveBeenCalled();
+  });
+
+  describe('when failOnWarnings is true', () => {
+    it('should returns true when there is no error or warning', async () => {
+      const service = new MrServiceMock();
+      const gitLab = new GitLab(service, true, true);
+
+      const result = await gitLab.report([untouchedError, untouchedWarning]);
+
+      expect(result).toBe(true);
+    });
+
+    it('should returns false when there is some error', async () => {
+      const service = new MrServiceMock();
+      const gitLab = new GitLab(service, true, true);
+
+      const result = await gitLab.report([
+        touchFileError,
+        untouchedError,
+        untouchedWarning,
+      ]);
+
+      expect(result).toBe(false);
+    });
+
+    it('should returns false when there is some warnings', async () => {
+      const service = new MrServiceMock();
+      const gitLab = new GitLab(service, true, true);
+
+      const result = await gitLab.report([
+        touchFileWarning,
+        untouchedError,
+        untouchedWarning,
+      ]);
+
+      expect(result).toBe(false);
+    });
   });
 });

--- a/src/Provider/GitLab/GitLab.ts
+++ b/src/Provider/GitLab/GitLab.ts
@@ -19,6 +19,7 @@ export class GitLab implements VCS {
   constructor(
     private readonly mrService: IGitLabMRService,
     private readonly removeOldComment: boolean,
+    private readonly failOnWarnings: boolean = false,
   ) {}
 
   async report(logs: LogType[]): Promise<boolean> {
@@ -35,7 +36,7 @@ export class GitLab implements VCS {
 
       Log.info('Report commit status completed');
 
-      return this.nError === 0; // fail the process if there's error
+      return this.failOnWarnings ? this.nError + this.nWarning === 0 : this.nError === 0; // fail the process if there's error/warnings
     } catch (err) {
       Log.error('GitLab report failed', err);
       throw err;

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,9 +28,17 @@ class App {
         configs.githubRepoUrl,
         configs.githubPr,
       );
-      this.vcs = new GitHub(githubPRService, configs.removeOldComment);
+      this.vcs = new GitHub(
+        githubPRService,
+        configs.removeOldComment,
+        configs.failOnWarnings,
+      );
     } else if (configs.vcs === 'gitlab') {
-      this.vcs = new GitLab(new GitLabMRService(), configs.removeOldComment);
+      this.vcs = new GitLab(
+        new GitLabMRService(),
+        configs.removeOldComment,
+        configs.failOnWarnings,
+      );
     }
 
     const logs = await this.parseBuildData(configs.buildLogFile);


### PR DESCRIPTION
Added an option to make codecoach fail when warnings are found. This option is off by default since it's not what you expect from warnings, but it could be useful for projects that want stricter checks.

## Changes
 - Added `failOnWarnings` configuration option (off by default).
 - Made Gitlab and Github services fail the pipeline if `failOnWarnings` if true and warnings are present.
 - Added unit tests for `failOnWarnings`.
 - Fix: Swapped `VCS: GitLab > should returns true when there is no error` and `VCS: GitLab > should returns false when there is some error` test cases. Based on the assertion, I think these tests should the be other way around?