### PR TITLE
Add double space after each issue reporting to the same line

### DIFF
--- a/src/Provider/utils/commentUtil.ts
+++ b/src/Provider/utils/commentUtil.ts
@@ -14,7 +14,7 @@ export function groupComments(logs: LogType[]): Comment[] {
     const currentText = map?.[file]?.[line]?.text ?? '';
 
     const nextObject: Comment = {
-      text: `${currentText}\n${text}`,
+      text: `${currentText}${text}  \n`,
       errors: currentErrors + (severity === LogSeverity.error ? 1 : 0),
       warnings: currentWarnings + (severity === LogSeverity.warning ? 1 : 0),
       file,


### PR DESCRIPTION
This problem only exist on GitLab since GitHub Markdown treat line break as a line break in the rendered text.
While GitLab does not as it's following CommonMark specs. Thus, we need the double space at the end of the line to indicate the line break.

https://spec.commonmark.org/0.30/#hard-line-breaks
https://docs.gitlab.com/ee/user/markdown.html#newlines