### PR TITLE
Add silent mode

### DIFF
--- a/src/Config/@types/configArgument.ts
+++ b/src/Config/@types/configArgument.ts
@@ -16,4 +16,5 @@ export type ConfigArgument = {
   failOnWarnings: boolean;
   suppressRules: string[];
   dryRun: boolean;
+  silent: boolean;
 };

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -121,6 +121,11 @@ and <cwd> is build root directory (optional (Will use current context as cwd)).
     type: 'boolean',
     default: false,
   })
+  .option('silent', {
+    describe: 'Disable the comment but still report job status to the VCS',
+    type: 'boolean',
+    default: false,
+  })
   .check((options) => {
     if (options.dryRun) return true;
     if (typeof options.vcs === 'undefined') throw 'VCS type is required';

--- a/src/Provider/@interfaces/VCSEngineConfig.ts
+++ b/src/Provider/@interfaces/VCSEngineConfig.ts
@@ -1,4 +1,5 @@
 export interface VCSEngineConfig {
   removeOldComment: boolean;
   failOnWarnings: boolean;
+  silent: boolean;
 }

--- a/src/Provider/CommonVCS/VCSEngine.spec.ts
+++ b/src/Provider/CommonVCS/VCSEngine.spec.ts
@@ -8,6 +8,7 @@ import { Comment } from '../../AnalyzerBot/@types/CommentTypes';
 const config: VCSEngineConfig = {
   removeOldComment: false,
   failOnWarnings: false,
+  silent: false,
 };
 
 function createMockAdapter(): VCSAdapter {
@@ -123,6 +124,16 @@ describe('VCSEngine', () => {
       const { adapter, analyzer, vcs } = setup();
       await vcs.report([]);
       expect(adapter.wrapUp).toBeCalledWith(analyzer);
+    });
+
+    it('should not call adapter to add comments when silent mode is on', async () => {
+      const { adapter, analyzer, vcs } = setup({ ...config, silent: true });
+      analyzer.shouldGenerateOverview = jest.fn().mockReturnValue(true);
+      analyzer.comments = [comment1, comment2];
+
+      await vcs.report([]);
+      expect(adapter.createReviewComment).not.toBeCalled();
+      expect(adapter.createComment).not.toBeCalled();
     });
   });
 });

--- a/src/Provider/CommonVCS/VCSEngine.ts
+++ b/src/Provider/CommonVCS/VCSEngine.ts
@@ -22,12 +22,16 @@ export class VCSEngine implements VCS {
         await this.adapter.removeExistingComments();
       }
 
-      await Promise.all(
-        this.analyzerBot.comments.map((c) => this.createReviewComment(c)),
-      );
-      await this.createSummaryComment();
+      if (!this.config.silent) {
+        await Promise.all(
+          this.analyzerBot.comments.map((c) => this.createReviewComment(c)),
+        );
+        await this.createSummaryComment();
 
-      Log.info('Report commit status completed');
+        Log.info('Report commit status completed');
+      } else {
+        Log.info('Silent mode is on. No inline comment nor summary will be produced.');
+      }
     } catch (err) {
       Log.error(`${this.adapter.getName()} report failed`, err);
       throw err;


### PR DESCRIPTION
There's a case when we don't want comments but still want to report failing status to CI jobs.

The existing `--dryrun` will skip the status report so we need this new flag :D